### PR TITLE
DM-1824 : with the latest version of Chronicle queue we need to disable the thread safety check from the lib, as we are already taking care of the thread safety in the SNMP agent.

### DIFF
--- a/snmp/snmp-device-gateway/src/main/java/com/cumulocity/agent/snmp/config/GatewayProperties.java
+++ b/snmp/snmp-device-gateway/src/main/java/com/cumulocity/agent/snmp/config/GatewayProperties.java
@@ -33,9 +33,6 @@ public class GatewayProperties {
 	@Autowired
 	private BootstrapProperties bootstrapProperties;
 
-	@Autowired
-	private SnmpProperties snmpProperties;
-
 	@Value("#{'${gateway.identifier:snmp-agent}'.trim()}")
 	private String gatewayIdentifier;
 

--- a/snmp/snmp-device-gateway/src/main/java/com/cumulocity/agent/snmp/persistence/AbstractQueue.java
+++ b/snmp/snmp-device-gateway/src/main/java/com/cumulocity/agent/snmp/persistence/AbstractQueue.java
@@ -209,6 +209,7 @@ public abstract class AbstractQueue implements Queue {
 
         DocumentContext documentContext = null;
         try {
+            tailer.disableThreadSafetyCheck(true);
             documentContext = tailer.readingDocument();
             if(documentContext.isPresent()) {
                 pauser.reset();


### PR DESCRIPTION
…le the thread safety check from the lib, as we are already taking care of the thread safety in the SNMP agent.