### PR TITLE
MTM-55935 fixes snmp tests to not pollute user home directory

### DIFF
--- a/snmp/snmp-device-gateway/src/main/java/com/cumulocity/agent/snmp/bootstrap/repository/DeviceCredentialsStore.java
+++ b/snmp/snmp-device-gateway/src/main/java/com/cumulocity/agent/snmp/bootstrap/repository/DeviceCredentialsStore.java
@@ -40,7 +40,7 @@ public class DeviceCredentialsStore extends AbstractMap<DeviceCredentialsKey, St
                 10_000,
                 10, // Chronicle Map is optimized for 10 entries as we actually store only one entry with device credentials
                 Paths.get(
-                        System.getProperty("user.home"),
+                        gatewayProperties.getGatewayDatabaseBaseDir(),
                         ".snmp",
                         gatewayProperties.getGatewayIdentifier().toLowerCase(),
                         "chronicle",

--- a/snmp/snmp-device-gateway/src/main/java/com/cumulocity/agent/snmp/config/GatewayProperties.java
+++ b/snmp/snmp-device-gateway/src/main/java/com/cumulocity/agent/snmp/config/GatewayProperties.java
@@ -36,6 +36,9 @@ public class GatewayProperties {
 	@Value("#{'${gateway.identifier:snmp-agent}'.trim()}")
 	private String gatewayIdentifier;
 
+	@Value("#{'${gateway.db.baseDir:${user.home}}'.trim()}")
+	private String gatewayDatabaseBaseDir;
+
 	@Value("#{'${gateway.bootstrapFixedDelay:10000}'.trim()}")
 	private int bootstrapFixedDelay;
 

--- a/snmp/snmp-device-gateway/src/main/java/com/cumulocity/agent/snmp/platform/pubsub/queue/AlarmQueue.java
+++ b/snmp/snmp-device-gateway/src/main/java/com/cumulocity/agent/snmp/platform/pubsub/queue/AlarmQueue.java
@@ -33,7 +33,7 @@ public class AlarmQueue extends AbstractQueue {
     public AlarmQueue(GatewayProperties gatewayProperties) {
         super(ALARM_QUEUE_NAME,
                 Paths.get(
-                        System.getProperty("user.home"),
+                        gatewayProperties.getGatewayDatabaseBaseDir(),
                         ".snmp",
                         gatewayProperties.getGatewayIdentifier().toLowerCase(),
                         "chronicle",

--- a/snmp/snmp-device-gateway/src/main/java/com/cumulocity/agent/snmp/platform/pubsub/queue/EventQueue.java
+++ b/snmp/snmp-device-gateway/src/main/java/com/cumulocity/agent/snmp/platform/pubsub/queue/EventQueue.java
@@ -33,7 +33,7 @@ public class EventQueue extends AbstractQueue {
     public EventQueue(GatewayProperties gatewayProperties) {
         super(EVENT_QUEUE_NAME,
                 Paths.get(
-                        System.getProperty("user.home"),
+                        gatewayProperties.getGatewayDatabaseBaseDir(),
                         ".snmp",
                         gatewayProperties.getGatewayIdentifier().toLowerCase(),
                         "chronicle",

--- a/snmp/snmp-device-gateway/src/main/java/com/cumulocity/agent/snmp/platform/pubsub/queue/MeasurementQueue.java
+++ b/snmp/snmp-device-gateway/src/main/java/com/cumulocity/agent/snmp/platform/pubsub/queue/MeasurementQueue.java
@@ -33,7 +33,7 @@ public class MeasurementQueue extends AbstractQueue {
     public MeasurementQueue(GatewayProperties gatewayProperties) {
         super(MEASUREMENT_QUEUE_NAME,
                 Paths.get(
-                        System.getProperty("user.home"),
+                        gatewayProperties.getGatewayDatabaseBaseDir(),
                         ".snmp",
                         gatewayProperties.getGatewayIdentifier().toLowerCase(),
                         "chronicle",

--- a/snmp/snmp-device-gateway/src/test/java/com/cumulocity/agent/snmp/bootstrap/repository/DeviceCredentialsStoreTest.java
+++ b/snmp/snmp-device-gateway/src/test/java/com/cumulocity/agent/snmp/bootstrap/repository/DeviceCredentialsStoreTest.java
@@ -33,6 +33,7 @@ import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 
+import static com.cumulocity.agent.snmp.util.WorkspaceUtils.getWorkspacePath;
 import static org.junit.Assert.*;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -49,7 +50,7 @@ public class DeviceCredentialsStoreTest {
     @Before
     public void setUp() {
         persistentFilePath = Paths.get(
-                System.getProperty("user.home"),
+                getWorkspacePath(),
                 ".snmp",
                 this.getClass().getSimpleName().toLowerCase(),
                 "chronicle",
@@ -57,6 +58,7 @@ public class DeviceCredentialsStoreTest {
                 "device-credentials-store.dat");
 
         Mockito.when(gatewayProperties.getGatewayIdentifier()).thenReturn(this.getClass().getSimpleName());
+        Mockito.when(gatewayProperties.getGatewayDatabaseBaseDir()).thenReturn(getWorkspacePath());
         deviceCredentialsStore = new DeviceCredentialsStore(gatewayProperties);
     }
 

--- a/snmp/snmp-device-gateway/src/test/java/com/cumulocity/agent/snmp/persistence/AbstractMapTest.java
+++ b/snmp/snmp-device-gateway/src/test/java/com/cumulocity/agent/snmp/persistence/AbstractMapTest.java
@@ -31,6 +31,7 @@ import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
+import static com.cumulocity.agent.snmp.util.WorkspaceUtils.getWorkspacePath;
 import static org.junit.Assert.*;
 
 public class AbstractMapTest {
@@ -43,7 +44,7 @@ public class AbstractMapTest {
     @Before
     public void setUp() {
         persistentFilePath = Paths.get(
-                System.getProperty("user.home"),
+                getWorkspacePath(),
                 ".snmp",
                 "chronicle",
                 "maps",
@@ -75,7 +76,7 @@ public class AbstractMapTest {
     @Test
     public void shouldCreatePersistenceFileIfRequired() {
         Path filePath = Paths.get(
-                System.getProperty("user.home"),
+                getWorkspacePath(),
                 ".snmp",
                 "test",
                 AbstractMapImplForTest.class.getSimpleName().toLowerCase() + ".dat");

--- a/snmp/snmp-device-gateway/src/test/java/com/cumulocity/agent/snmp/persistence/AbstractQueueTest.java
+++ b/snmp/snmp-device-gateway/src/test/java/com/cumulocity/agent/snmp/persistence/AbstractQueueTest.java
@@ -21,8 +21,8 @@ package com.cumulocity.agent.snmp.persistence;
 import net.openhft.chronicle.queue.impl.single.QueueFileShrinkManager;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Test;
 import org.junit.Ignore;
+import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
@@ -33,6 +33,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import static com.cumulocity.agent.snmp.util.WorkspaceUtils.getWorkspacePath;
 import static org.junit.Assert.*;
 
 public class AbstractQueueTest {
@@ -44,7 +45,7 @@ public class AbstractQueueTest {
     @Before
     public void setUp() {
         persistentFolderPath = Paths.get(
-                System.getProperty("user.home"),
+                getWorkspacePath(),
                 ".snmp",
                 this.getClass().getSimpleName().toLowerCase(),
                 "chronicle",
@@ -292,7 +293,7 @@ public class AbstractQueueTest {
     public class StoreFileListenerForDeletionTest {
 
         private Path parentFolderPath = Paths.get(
-                System.getProperty("user.home"),
+                getWorkspacePath(),
                 ".snmp",
                 this.getClass().getSimpleName().toLowerCase(),
                 "chronicle",

--- a/snmp/snmp-device-gateway/src/test/java/com/cumulocity/agent/snmp/persistence/StoreFileListenerForDeletionTest.java
+++ b/snmp/snmp-device-gateway/src/test/java/com/cumulocity/agent/snmp/persistence/StoreFileListenerForDeletionTest.java
@@ -38,6 +38,7 @@ import java.util.Calendar;
 import java.util.Comparator;
 import java.util.GregorianCalendar;
 
+import static com.cumulocity.agent.snmp.util.WorkspaceUtils.getWorkspacePath;
 import static org.junit.Assert.*;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -50,7 +51,7 @@ public class StoreFileListenerForDeletionTest {
     private final Calendar NOW = new GregorianCalendar();
 
     private Path parentFolderPath = Paths.get(
-            System.getProperty("user.home"),
+            getWorkspacePath(),
             ".snmp",
             this.getClass().getSimpleName().toLowerCase());
 

--- a/snmp/snmp-device-gateway/src/test/java/com/cumulocity/agent/snmp/platform/pubsub/queue/AlarmQueueTest.java
+++ b/snmp/snmp-device-gateway/src/test/java/com/cumulocity/agent/snmp/platform/pubsub/queue/AlarmQueueTest.java
@@ -32,6 +32,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+import static com.cumulocity.agent.snmp.util.WorkspaceUtils.getWorkspacePath;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -49,9 +50,10 @@ public class AlarmQueueTest {
     @Before
     public void setUp() {
         Mockito.when(gatewayProperties.getGatewayIdentifier()).thenReturn(this.getClass().getSimpleName());
+        Mockito.when(gatewayProperties.getGatewayDatabaseBaseDir()).thenReturn(getWorkspacePath());
 
         persistentFolderPath = Paths.get(
-                System.getProperty("user.home"),
+                getWorkspacePath(),
                 ".snmp",
                 gatewayProperties.getGatewayIdentifier().toLowerCase(),
                 "chronicle",

--- a/snmp/snmp-device-gateway/src/test/java/com/cumulocity/agent/snmp/platform/pubsub/queue/EventQueueTest.java
+++ b/snmp/snmp-device-gateway/src/test/java/com/cumulocity/agent/snmp/platform/pubsub/queue/EventQueueTest.java
@@ -32,6 +32,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+import static com.cumulocity.agent.snmp.util.WorkspaceUtils.getWorkspacePath;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -49,9 +50,10 @@ public class EventQueueTest {
     @Before
     public void setUp() {
         Mockito.when(gatewayProperties.getGatewayIdentifier()).thenReturn(this.getClass().getSimpleName());
+        Mockito.when(gatewayProperties.getGatewayDatabaseBaseDir()).thenReturn(getWorkspacePath());
 
         persistentFolderPath = Paths.get(
-                System.getProperty("user.home"),
+                getWorkspacePath(),
                 ".snmp",
                 gatewayProperties.getGatewayIdentifier().toLowerCase(),
                 "chronicle",

--- a/snmp/snmp-device-gateway/src/test/java/com/cumulocity/agent/snmp/platform/pubsub/queue/MeasurementQueueTest.java
+++ b/snmp/snmp-device-gateway/src/test/java/com/cumulocity/agent/snmp/platform/pubsub/queue/MeasurementQueueTest.java
@@ -32,6 +32,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+import static com.cumulocity.agent.snmp.util.WorkspaceUtils.getWorkspacePath;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -49,9 +50,10 @@ public class MeasurementQueueTest {
     @Before
     public void setUp() {
         Mockito.when(gatewayProperties.getGatewayIdentifier()).thenReturn(this.getClass().getSimpleName());
+        Mockito.when(gatewayProperties.getGatewayDatabaseBaseDir()).thenReturn(getWorkspacePath());
 
         persistentFolderPath = Paths.get(
-                System.getProperty("user.home"),
+                getWorkspacePath(),
                 ".snmp",
                 gatewayProperties.getGatewayIdentifier().toLowerCase(),
                 "chronicle",

--- a/snmp/snmp-device-gateway/src/test/java/com/cumulocity/agent/snmp/util/WorkspaceUtils.java
+++ b/snmp/snmp-device-gateway/src/test/java/com/cumulocity/agent/snmp/util/WorkspaceUtils.java
@@ -1,0 +1,17 @@
+package com.cumulocity.agent.snmp.util;
+
+import lombok.experimental.UtilityClass;
+
+import static java.util.Optional.ofNullable;
+
+@UtilityClass
+public class WorkspaceUtils {
+
+    /**
+     * @return path to write temporary files for tests.
+     */
+    public static String getWorkspacePath() {
+        return ofNullable(System.getenv("WORKSPACE"))
+                .orElseGet(() -> System.getProperty("java.io.tmpdir"));
+    }
+}


### PR DESCRIPTION
`snmp` tests will no use `WORKSPACE` environment variable if defined or `java.io.tmpdir` as a fallback as base path for storing files during tests instead of polluting current user home directory.