### PR TITLE
[MTM-56084]: adding new java client for mTLS protocol using X509 certificate

### DIFF
--- a/x509-rest-client/README.md
+++ b/x509-rest-client/README.md
@@ -1,0 +1,24 @@
+##### The repository contains an example Java REST client with support for X509.certificates.  
+
+Before run, configuration is required. 
+
+Place in resource folder keystore and truststore file. 
+
+In X509RestClient.java provide:
+
+
+* **KEYSTORE_NAME** -  key store file name (placed in resource folder)  
+* **KEYSTORE_PASSWORD** - key store password
+* **KEYSTORE_FORMAT** - key store format (eg. 'jks')  
+* **TRUSTSTORE_NAME** - trust store file name (placed in resource folder)  
+* **TRUSTSTORE_PASSWORD** - trust store password  
+* **TRUSTSTORE_FORMAT** - trust store format (eg. 'jks')  
+* **CLIENT_ID** - client Id which matches the certificate subject common name  
+* **PLATFORM_URL** - URL for mTLS connection
+* **X_SSL_CERT_CHAIN** - constant for header key `x-ssl-cert-chain`
+* **DEVICE_ACCESS_TOKEN_PATH** - API endpoint for making mTLS protocol
+* **LOCAL_DEVICE_CHAIN** - value of header key `x-ssl-cert-chain` which contains full device chain
+
+
+After running, client tries to establish mTLS connection using provided PLATFORM_URL, endpoint and client full chain.  
+Successful connection provide device access token: in response with 200 HTTP code.

--- a/x509-rest-client/pom.xml
+++ b/x509-rest-client/pom.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>c8y-examples</artifactId>
+        <groupId>c8y.example</groupId>
+        <version>${revision}${changelist}</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>x509-rest-client</artifactId>
+    <name>Cumulocity :: Examples :: Sample x509 REST client</name>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/x509-rest-client/src/main/java/com/c8y/x509/X509RestClient.java
+++ b/x509-rest-client/src/main/java/com/c8y/x509/X509RestClient.java
@@ -1,0 +1,94 @@
+package com.c8y.x509;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.security.KeyManagementException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.UnrecoverableKeyException;
+import java.security.cert.CertificateException;
+
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManagerFactory;
+
+public class X509RestClient {
+
+	// Configuration
+	private static final String KEYSTORE_NAME = "";
+	private static final String KEYSTORE_PASSWORD = "";
+	private static final String KEYSTORE_FORMAT = "";
+	private static final String TRUSTSTORE_NAME = "";
+	private static final String TRUSTSTORE_PASSWORD = "";
+	private static final String TRUSTSTORE_FORMAT = "";
+	private static final String PLATFORM_URL = "";
+	private static final String X_SSL_CERT_CHAIN = "x-ssl-cert-chain";
+	private static final String DEVICE_ACCESS_TOKEN_PATH = "/devicecontrol/deviceAccessToken";
+	private static final String LOCAL_DEVICE_CHAIN = "";
+	
+	//PEM format
+	// example. LOCAL_DEVICE_CHAIN = "-----BEGIN CERTIFICATE----- MIIDaDCCAlCgAwIBAgIUTPAh+EgbLfzb2JL/q7wT90ypqgcwDQYJKoZIhvcNAQEL BQAwTzELMAkGA1UEBhMCRVUxCzAJBgNVBAgMAlBMMRswGQYDVQQKDBJJb3QgRGV2 aWNlIEZhY3RvcnkxFjAUBgNVBAMMDUlvdERldkZhY3RvcnkwHhcNMjMxMjA4MDc0 MDU5WhcNMzMxMjA1MDc0MDU5WjBPMQswCQYDVQQGEwJFVTELMAkGA1UECAwCUEwx GzAZBgNVBAoMEklvdCBEZXZpY2UgRmFjdG9yeTEWMBQGA1UEAwwNSW90RGV2RmFj dG9yeTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKVSPuT68PMLjBX7 1jZpOX0SJx99pwCoIxpBAOyR7aC4CX6mpdTaogjKaHQeBZ84Hvfe7J2TWsNhGtYN JuBXy1hdUuzEt3eyQXKZu/kKQhNJ1UubSJdfmxWH1dZflUFFyq7DsBtfiyvrATFm TyoJiWNHzTOB7KiPjY/0jUXdqu2k+BCNDph+6rAGwIhaZcjTInYejfeZpP2yunoc yJ9AdAEYd0m6bawHUKUTtQpu2lcJ/a0al32KuKv1mSy1o+wGb26ah3Pk4OFtFgUf +SiVjWwGJjaPU080JZ6SBJmyKJeOe25fY9BqABJQTK/baKuaBEfPD274zi7ok2FL GET0dq8CAwEAAaM8MDowDAYDVR0TBAUwAwEB/zALBgNVHQ8EBAMCAuQwHQYDVR0O BBYEFBmEY6IFiPgNX8BHkSig8ucNHyDiMA0GCSqGSIb3DQEBCwUAA4IBAQBNKF67 2MTGo5Vd3BzK1DbBQFDt2N/Hf6S1w9j5r5sqxrNOahKumlRGQ591IubwiCGvY1HJ u+WnhN8eBVfM7qQMrrYSkwTuMEvo+CoOklliZU47ZAqPCdltRLKnIH+LkHiX/Gp9 memWXdThKMcMn8Zamt3LQ6/yypKjxuZRmHg3d9gqvh2K1497k+Yxx4R92EOR+GFw /QjUb+l7+eYxsjT0yvB/GXCWTgKH9KYZ5gr+FvmfCui196OHil2VZHBRuumsTR2r TmG3EC9g5UGWQ/xTU5xCktrldo3CyzDVFOFziowOKmIHzfUUqrS/2fIPHmijTKCw ASFcQhNJJ0F/lfjm -----END CERTIFICATE-----";
+	public static void main(String[] args) throws Exception {
+		
+		TrustManagerFactory trustManagerFactory = getTrustManagerFactory();
+		KeyManagerFactory keyManagerFactory = getKeyManagerFactory();
+		SSLContext sslContext = getSSLContext(trustManagerFactory, keyManagerFactory);
+		HttpClient httpClient = HttpClient.newBuilder().sslContext(sslContext).build();
+		
+		HttpResponse<String> response = httpClient.send(buildRequest(), HttpResponse.BodyHandlers.ofString());
+		System.out.println(response.body());
+	}
+	private static SSLContext getSSLContext(TrustManagerFactory trustManagerFactory, KeyManagerFactory keyManagerFactory) {
+		try {
+			SSLContext sslContext = SSLContext.getInstance("TLS");
+			sslContext.init(keyManagerFactory.getKeyManagers(), trustManagerFactory.getTrustManagers(), null);
+			return sslContext;
+		} catch (NoSuchAlgorithmException | KeyManagementException exception) {
+			throw new RuntimeException("Error in creating SSLContext", exception);
+		}
+	}
+
+	private static HttpRequest buildRequest() {
+		try {
+			return HttpRequest.newBuilder().uri(new URI(PLATFORM_URL + DEVICE_ACCESS_TOKEN_PATH))
+					.POST(HttpRequest.BodyPublishers.noBody()).header("Accept", "application/json")
+					.header(X_SSL_CERT_CHAIN, LOCAL_DEVICE_CHAIN).build();
+		} catch (URISyntaxException uRISyntaxException) {
+			throw new RuntimeException("Error in creating SSLContext", uRISyntaxException);
+		}
+	}
+
+	private static TrustManagerFactory getTrustManagerFactory() {
+		try {
+			KeyStore trustStore = KeyStore.getInstance(TRUSTSTORE_FORMAT);
+			InputStream trustStoreFile = new FileInputStream(TRUSTSTORE_NAME);
+			trustStore.load(trustStoreFile, TRUSTSTORE_PASSWORD.toCharArray());
+			TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+			trustManagerFactory.init(trustStore);
+			return trustManagerFactory;
+		} catch (KeyStoreException | NoSuchAlgorithmException | CertificateException | IOException exception) {
+			throw new RuntimeException("Error in generating TrustManagerFactory value", exception);
+		}
+	}
+
+	private static KeyManagerFactory getKeyManagerFactory() {
+		try {
+			KeyStore trustStore = KeyStore.getInstance(KEYSTORE_FORMAT);
+			InputStream trustStoreFile = new FileInputStream(KEYSTORE_NAME);
+			trustStore.load(trustStoreFile, KEYSTORE_PASSWORD.toCharArray());
+			KeyManagerFactory keyManagerFactory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+			keyManagerFactory.init(trustStore, KEYSTORE_PASSWORD.toCharArray());
+			return keyManagerFactory;
+		} catch (KeyStoreException | NoSuchAlgorithmException | CertificateException | IOException
+				| UnrecoverableKeyException exception) {
+			throw new RuntimeException("Error creating KeyManagerFactory", exception);
+		}
+	}
+}


### PR DESCRIPTION
Documentation is available on :
https://sagportal.sharepoint.com/:w:/r/sites/IoTAnalyticsRnDOps/_layouts/15/doc2.aspx?sourcedoc=%7B489B6AA8-3AFA-44DC-BD83-32DDC4B93F43%7D&file=Enable%20mTLS%20for%20REST.docx&action=default&mobileredirect=true

API documentation :
https://github.softwareag.com/IOTA/cumulocity-openapi/pull/234/

This PR;s content is already reviewed and approved on https://github.com/SoftwareAG/cumulocity-examples/pull/114