### PR TITLE
[MTM-59215]: New port is open for device access token API

### DIFF
--- a/x509-rest-client/README.md
+++ b/x509-rest-client/README.md
@@ -15,6 +15,7 @@ In X509RestClient.java provide:
 * **TRUSTSTORE_FORMAT** - trust store format (eg. 'jks')  
 * **CLIENT_ID** - client Id which matches the certificate subject common name  
 * **PLATFORM_URL** - URL for mTLS connection
+* **PLATFORM_MTLS_PORT** - Port for established mTLS connection using certificates
 * **X_SSL_CERT_CHAIN** - constant for header key `x-ssl-cert-chain`
 * **DEVICE_ACCESS_TOKEN_PATH** - API endpoint for making mTLS protocol
 * **LOCAL_DEVICE_CHAIN** - value of header key `x-ssl-cert-chain` which contains full device chain

--- a/x509-rest-client/src/main/java/com/c8y/x509/X509RestClient.java
+++ b/x509-rest-client/src/main/java/com/c8y/x509/X509RestClient.java
@@ -29,6 +29,7 @@ public class X509RestClient {
 	private static final String TRUSTSTORE_PASSWORD = "";
 	private static final String TRUSTSTORE_FORMAT = "";
 	private static final String PLATFORM_URL = "";
+	private static final String PLATFORM_MTLS_PORT = "2443";
 	private static final String X_SSL_CERT_CHAIN = "x-ssl-cert-chain";
 	private static final String DEVICE_ACCESS_TOKEN_PATH = "/devicecontrol/deviceAccessToken";
 	private static final String LOCAL_DEVICE_CHAIN = "";
@@ -57,7 +58,7 @@ public class X509RestClient {
 
 	private static HttpRequest buildRequest() {
 		try {
-			return HttpRequest.newBuilder().uri(new URI(PLATFORM_URL + DEVICE_ACCESS_TOKEN_PATH))
+			return HttpRequest.newBuilder().uri(new URI(PLATFORM_URL + ":" + PLATFORM_MTLS_PORT + DEVICE_ACCESS_TOKEN_PATH))
 					.POST(HttpRequest.BodyPublishers.noBody()).header("Accept", "application/json")
 					.header(X_SSL_CERT_CHAIN, LOCAL_DEVICE_CHAIN).build();
 		} catch (URISyntaxException uRISyntaxException) {


### PR DESCRIPTION
https://cumulocity.atlassian.net/browse/MTM-59215
For reviewers: We have bug on CICD environment https://itrac.eur.ad.sag/browse/IOT-20060 so we need to introduce a new port 2443 for device access token API.
Please find more information on https://sagportal.sharepoint.com/:w:/r/sites/IoTAnalyticsRnDOps/_layouts/15/Doc.aspx?sourcedoc=%7B28EC5A74-BB5F-4E5C-B688-D7386F84AD0D%7D&file=mTLS_REST_Popup_Issue.docx&action=default&mobileredirect=true