### PR TITLE
[MTM-59554] allow to export only device certificate optionally

### DIFF
--- a/mqtt-client/scripts/02moveCertificatesToKeystore.sh
+++ b/mqtt-client/scripts/02moveCertificatesToKeystore.sh
@@ -6,6 +6,11 @@ set -x
 NAME=iot-device-0001
 FILES_WITH_CERTIFICATES="$NAME-cert.pem iot-cert.pem"
 
+# Check for the --leafonly option
+if [[ "$1" == "--leafonly" ]]; then
+  FILES_WITH_CERTIFICATES="$NAME-cert.pem"
+fi
+
 rm chain-$NAME.pem chain-with-private-key-$NAME.p12 chain-with-private-key-$NAME.jks || echo "Nothing to remove"
 
 cat $FILES_WITH_CERTIFICATES > chain-$NAME.pem


### PR DESCRIPTION
Device now can connect to platform by leaf certificate only provided the immediate issuer is in the tenant trust store. This PR updates the doc about this change.

Related change: https://github.com/SoftwareAG/c8y-docs/pull/2182