### PR TITLE
[BACKPORT][release/y2025] MTM-58265 - add support for event binary api

### DIFF
--- a/tracker-agent/src/main/java/c8y/trackeragent/TrackerPlatform.java
+++ b/tracker-agent/src/main/java/c8y/trackeragent/TrackerPlatform.java
@@ -17,6 +17,7 @@ import com.cumulocity.sdk.client.audit.AuditRecordApi;
 import com.cumulocity.sdk.client.devicecontrol.DeviceControlApi;
 import com.cumulocity.sdk.client.devicecontrol.DeviceCredentialsApi;
 import com.cumulocity.sdk.client.event.EventApi;
+import com.cumulocity.sdk.client.event.EventBinaryApi;
 import com.cumulocity.sdk.client.identity.IdentityApi;
 import com.cumulocity.sdk.client.inventory.BinariesApi;
 import com.cumulocity.sdk.client.inventory.InventoryApi;
@@ -127,6 +128,17 @@ public class TrackerPlatform implements Platform {
                 return orig.getBinariesApi();
             }
 
+        }.get();
+    }
+
+    @Override
+    public EventBinaryApi getEventBinaryApi() throws SDKException {
+        return new CachedApiGetter<EventBinaryApi>(EventBinaryApi.class) {
+
+            @Override
+            public EventBinaryApi call() throws Exception{
+                return orig.getEventBinaryApi();
+            }
         }.get();
     }
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `develop` to `release/y2025`:
 - https://github.com/Cumulocity-IoT/cumulocity-examples/pull/140