### PR TITLE
[MTM-65144] Dependabot/maven/bouncycastle.version 1.83

### DIFF
--- a/mqtt-service/java-simple-pulsar-client/pom.xml
+++ b/mqtt-service/java-simple-pulsar-client/pom.xml
@@ -36,6 +36,21 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcpkix-jdk18on</artifactId>
+                <version>${bouncycastle.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcprov-jdk18on</artifactId>
+                <version>${bouncycastle.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcutil-jdk18on</artifactId>
+                <version>${bouncycastle.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/mqtt-service/java-simple-pulsar-client/pom.xml
+++ b/mqtt-service/java-simple-pulsar-client/pom.xml
@@ -24,7 +24,7 @@
     <properties>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
-        <pulsar.version>4.1.2</pulsar.version>
+        <pulsar.version>4.0.6</pulsar.version>
     </properties>
 
     <dependencyManagement>
@@ -35,6 +35,21 @@
                 <version>${pulsar.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcpkix-jdk18on</artifactId>
+                <version>${bouncycastle.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcprov-jdk18on</artifactId>
+                <version>${bouncycastle.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcutil-jdk18on</artifactId>
+                <version>${bouncycastle.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/mqtt-service/java-simple-pulsar-client/pom.xml
+++ b/mqtt-service/java-simple-pulsar-client/pom.xml
@@ -24,7 +24,7 @@
     <properties>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
-        <pulsar.version>4.0.6</pulsar.version>
+        <pulsar.version>4.1.2</pulsar.version>
     </properties>
 
     <dependencyManagement>

--- a/mqtt-service/java-simple-pulsar-client/pom.xml
+++ b/mqtt-service/java-simple-pulsar-client/pom.xml
@@ -36,21 +36,6 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-            <dependency>
-                <groupId>org.bouncycastle</groupId>
-                <artifactId>bcpkix-jdk18on</artifactId>
-                <version>${bouncycastle.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.bouncycastle</groupId>
-                <artifactId>bcprov-jdk18on</artifactId>
-                <version>${bouncycastle.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.bouncycastle</groupId>
-                <artifactId>bcutil-jdk18on</artifactId>
-                <version>${bouncycastle.version}</version>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
 
     <c8y.version>${project.version}</c8y.version>
     <spring-boot.version>3.5.5</spring-boot.version>
+    <bouncycastle.version>1.83</bouncycastle.version>
   </properties>
 
   <profiles>
@@ -107,6 +108,7 @@
         <version>${c8y.version}</version>
       </dependency>
     </dependencies>
+
   </dependencyManagement>
 
   <build>


### PR DESCRIPTION
Bump bouncycastle version to 1.83
java-simple-pulsar-client 4.0.6 contains dependencies to bouncycastle 1.78.1
This is bumped to verson 1.81 because the latest pulsar version is 4.1.2 with bouncycastle version 1.81.

Ticket:

- https://cumulocity.atlassian.net/browse/MTM-65144

Related PR:

- https://github.com/Cumulocity-IoT/cumulocity-clients-java-internal/pull/364
- https://github.com/Cumulocity-IoT/cumulocity-agents/pull/1883