### PR TITLE
[MTM-64805] comment out java-pulsar-microservice, since java-sdk build is failing

### DIFF
--- a/mqtt-service/pom.xml
+++ b/mqtt-service/pom.xml
@@ -18,7 +18,7 @@
 
     <modules>
         <module>java-simple-pulsar-client</module>
-        <module>java-pulsar-microservice</module>
+<!--        <module>java-pulsar-microservice</module>-->
     </modules>
 
     <build>


### PR DESCRIPTION
Related PR in java-sdk: https://github.com/Cumulocity-IoT/cumulocity-clients-java-internal/pull/408
failing because of 

```
[ERROR] Failed to execute goal com.coderplus.maven.plugins:copy-rename-maven-plugin:1.0.1:copy (rename-file) on project java-pulsar-ms: sourceFile /home/jenkins/agent/workspace/java-sdk-pre-merge_PR-420/cumulocity-examples/mqtt-service/java-pulsar-microservice/target/java-pulsar-ms-2026.23.0.420.1.sdk.zip does not exist -> [Help 1]

org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal com.coderplus.maven.plugins:copy-rename-maven-plugin:1.0.1:copy (rename-file) on project java-pulsar-ms: sourceFile /home/jenkins/agent/workspace/java-sdk-pre-merge_PR-420/cumulocity-examples/mqtt-service/java-pulsar-microservice/target/java-pulsar-ms-2026.23.0.420.1.sdk.zip does not exist
    at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute2 (MojoExecutor.java:333)
    at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute (MojoExecutor.java:316)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:212)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:174)
    at org.apache.maven.lifecycle.internal.MojoExecutor.access$000 (MojoExecutor.java:75)
    at org.apache.maven.lifecycle.internal.MojoExecutor$1.run (MojoExecutor.java:162)
    at org.apache.maven.plugin.DefaultMojosExecutionStrategy.execute (DefaultMojosExecutionStrategy.java:39)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:159)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:105)
    at org.apache.maven.lifecycle.internal.builder.multithreaded.MultiThreadedBuilder$1.call (MultiThreadedBuilder.java:193)
    at org.apache.maven.lifecycle.internal.builder.multithreaded.MultiThreadedBuilder$1.call (MultiThreadedBuilder.java:180)
    at java.util.concurrent.FutureTask.run (FutureTask.java:264)
    at java.util.concurrent.Executors$RunnableAdapter.call (Executors.java:539)
    at java.util.concurrent.FutureTask.run (FutureTask.java:264)
    at java.util.concurrent.ThreadPoolExecutor.runWorker (ThreadPoolExecutor.java:1136)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run (ThreadPoolExecutor.java:635)
    at java.lang.Thread.run (Thread.java:840)
Caused by: org.apache.maven.plugin.MojoExecutionException: sourceFile /home/jenkins/agent/workspace/java-sdk-pre-merge_PR-420/cumulocity-examples/mqtt-service/java-pulsar-microservice/target/java-pulsar-ms-2026.23.0.420.1.sdk.zip does not exist
```