### PR TITLE
MTM Spring Boot upgrade from 3.5 to 4.1 (clients-java 2026.40.2001)

### DIFF
--- a/hello-world-microservice/pom.xml
+++ b/hello-world-microservice/pom.xml
@@ -10,7 +10,7 @@
     <version>${revision}${changelist}</version>
 
     <properties>
-        <revision>2026.42.0</revision>
+        <revision>2026.40.2001</revision>
         <changelist>-SNAPSHOT</changelist>
 
         <java.version>17</java.version>
@@ -19,7 +19,7 @@
         <main.class>c8y.example.helloworld.HelloWorldMain</main.class>
 
         <c8y.version>${revision}${changelist}</c8y.version>
-        <spring-boot.version>3.5.11</spring-boot.version>
+        <spring-boot.version>4.1.0</spring-boot.version>
     </properties>
 
     <dependencyManagement>

--- a/java-agent/assembly/pom.xml
+++ b/java-agent/assembly/pom.xml
@@ -12,7 +12,7 @@
     <description>Base assembly package for all environments</description>
 
     <properties>
-        <revision>2026.42.0</revision>
+        <revision>2026.40.2001</revision>
         <changelist>-SNAPSHOT</changelist>
         <nexus.port>443</nexus.port>
     </properties>

--- a/lora-codec-twtg-neon/pom.xml
+++ b/lora-codec-twtg-neon/pom.xml
@@ -31,7 +31,7 @@
         <slf4j.version>1.7.32</slf4j.version>
         <graalvm.version>22.0.0</graalvm.version>
 
-        <spring-boot-dependencies.version>3.5.11</spring-boot-dependencies.version>
+        <spring-boot-dependencies.version>4.1.0</spring-boot-dependencies.version>
         <microservice.name>lora-codec-twtg-neon</microservice.name>
         <main.class>com.cumulocity.lora.codec.twtg.neon.Application</main.class>
     </properties>

--- a/microservices/hello-kotlin/pom.xml
+++ b/microservices/hello-kotlin/pom.xml
@@ -16,7 +16,8 @@
 
     <properties>
         <jetbrains-annotations.version>23.0.0</jetbrains-annotations.version>
-        <kotlin.version>1.9.25</kotlin.version>
+        <kotlin.version>2.3.21</kotlin.version> <!-- Spring Boot 4 requires Kotlin 2.2+; aligned with the version managed by the Spring Boot 4.1 BOM -->
+
         <springmockk.version>4.0.2</springmockk.version>
     </properties>
 
@@ -86,6 +87,12 @@
                     <artifactId>mockito-core</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <!-- Spring Boot 4.0 moved @WebMvcTest / MockMvc test support out of spring-boot-starter-test. -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-webmvc-test</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework.security</groupId>

--- a/microservices/hello-kotlin/src/test/kotlin/c8y/example/hellokotlin/HelloKotlinControllerTest.kt
+++ b/microservices/hello-kotlin/src/test/kotlin/c8y/example/hellokotlin/HelloKotlinControllerTest.kt
@@ -9,7 +9,9 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.BeforeEach
 import org.springframework.beans.factory.annotation.Autowired
 
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.boot.web.server.autoconfigure.ServerProperties
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.http.MediaType
 import org.springframework.security.test.context.support.WithMockUser
@@ -18,6 +20,9 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
 
 @WebMvcTest
+// Spring Boot 4's @WebMvcTest slice no longer includes ServerProperties, which the microservice
+// security auto-configuration requires; register it explicitly.
+@EnableConfigurationProperties(ServerProperties::class)
 @Import(SecurityMocksInitializer::class)
 internal class HelloKotlinControllerTest(@Autowired val mockMvc: MockMvc, @Autowired val mocksInitializer: SecurityMocksInitializer) {
 

--- a/microservices/iptracker-microservice/pom.xml
+++ b/microservices/iptracker-microservice/pom.xml
@@ -9,12 +9,12 @@
   <url>http://maven.apache.org</url>
 
   <properties>
-    <revision>2026.42.0</revision>
+    <revision>2026.40.2001</revision>
     <changelist>-SNAPSHOT</changelist>
     <java.version>17</java.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
-    <spring-boot.version>3.5.11</spring-boot.version>
+    <spring-boot.version>4.1.0</spring-boot.version>
     <c8y.version>${revision}${changelist}</c8y.version>
     <microservice.name>iptracker-microservice</microservice.name>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -11,9 +11,12 @@
   <packaging>pom</packaging>
 
   <properties>
-    <revision>2026.42.0</revision>
+    <revision>2026.40.2001</revision>
     <changelist>-SNAPSHOT</changelist>
 
+    <project.version>2026.40.2001-SNAPSHOT</project.version>
+    <project.parent.version>${project.version}</project.parent.version>
+    <c8y.microservice.version>${project.version}</c8y.microservice.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.version>17</java.version>
     <microservice.java.version>${java.version}</microservice.java.version>
@@ -21,7 +24,7 @@
     <nexus.basePath>/nexus/content/repositories</nexus.basePath>
 
     <c8y.version>${project.version}</c8y.version>
-    <spring-boot.version>3.5.11</spring-boot.version>
+    <spring-boot.version>4.1.0</spring-boot.version>
     <bouncycastle.version>1.83</bouncycastle.version>
   </properties>
 


### PR DESCRIPTION
Just for a first impression!!!

Mandatory changes to build cumulocity-examples against the Spring Boot 4.1 clients-java libraries (Spring Framework 7, Kotlin 2.x).

Versions:
- spring-boot 3.5.11 -> 4.1.0 (root pom, hello-world-microservice, iptracker-microservice; spring-boot-dependencies 3.5.11 -> 4.1.0 in lora-codec-twtg-neon)
- point examples at the upgraded clients (revision 2026.40.2001 / c8y.microservice.version)

hello-kotlin (the only module needing code/pom fixes):
- kotlin 1.9.25 -> 2.3.21 (Spring Boot 4 requires Kotlin 2.2+; aligned with the SB 4.1 BOM)
- @WebMvcTest moved to org.springframework.boot.webmvc.test.autoconfigure; add spring-boot-webmvc-test (test)
- @EnableConfigurationProperties(ServerProperties) in HelloKotlinControllerTest: SB4's @WebMvcTest slice no longer includes ServerProperties, required by the microservice security auto-configuration