### PR TITLE
MTM-67166 Spring Boot upgrade from 3.5.x to 4.0.7

### DIFF
--- a/hello-world-microservice/pom.xml
+++ b/hello-world-microservice/pom.xml
@@ -10,7 +10,7 @@
     <version>${revision}${changelist}</version>
 
     <properties>
-        <revision>2026.40.2001</revision>
+        <revision>2026.42.0</revision>
         <changelist>-SNAPSHOT</changelist>
 
         <java.version>17</java.version>

--- a/hello-world-microservice/pom.xml
+++ b/hello-world-microservice/pom.xml
@@ -10,7 +10,7 @@
     <version>${revision}${changelist}</version>
 
     <properties>
-        <revision>2026.42.0</revision>
+        <revision>2026.43.0</revision>
         <changelist>-SNAPSHOT</changelist>
 
         <java.version>17</java.version>

--- a/hello-world-microservice/pom.xml
+++ b/hello-world-microservice/pom.xml
@@ -10,7 +10,7 @@
     <version>${revision}${changelist}</version>
 
     <properties>
-        <revision>2026.42.0</revision>
+        <revision>2026.40.2001</revision>
         <changelist>-SNAPSHOT</changelist>
 
         <java.version>17</java.version>
@@ -19,7 +19,7 @@
         <main.class>c8y.example.helloworld.HelloWorldMain</main.class>
 
         <c8y.version>${revision}${changelist}</c8y.version>
-        <spring-boot.version>3.5.11</spring-boot.version>
+        <spring-boot.version>4.1.0</spring-boot.version>
     </properties>
 
     <dependencyManagement>

--- a/hello-world-microservice/pom.xml
+++ b/hello-world-microservice/pom.xml
@@ -19,7 +19,7 @@
         <main.class>c8y.example.helloworld.HelloWorldMain</main.class>
 
         <c8y.version>${revision}${changelist}</c8y.version>
-        <spring-boot.version>4.1.0</spring-boot.version>
+        <spring-boot.version>4.0.7</spring-boot.version>
     </properties>
 
     <dependencyManagement>

--- a/java-agent/assembly/pom.xml
+++ b/java-agent/assembly/pom.xml
@@ -12,7 +12,7 @@
     <description>Base assembly package for all environments</description>
 
     <properties>
-        <revision>2026.42.0</revision>
+        <revision>2026.43.0</revision>
         <changelist>-SNAPSHOT</changelist>
         <nexus.port>443</nexus.port>
     </properties>

--- a/java-agent/assembly/pom.xml
+++ b/java-agent/assembly/pom.xml
@@ -12,7 +12,7 @@
     <description>Base assembly package for all environments</description>
 
     <properties>
-        <revision>2026.42.0</revision>
+        <revision>2026.40.2001</revision>
         <changelist>-SNAPSHOT</changelist>
         <nexus.port>443</nexus.port>
     </properties>

--- a/java-agent/assembly/pom.xml
+++ b/java-agent/assembly/pom.xml
@@ -12,7 +12,7 @@
     <description>Base assembly package for all environments</description>
 
     <properties>
-        <revision>2026.40.2001</revision>
+        <revision>2026.42.0</revision>
         <changelist>-SNAPSHOT</changelist>
         <nexus.port>443</nexus.port>
     </properties>

--- a/lora-codec-twtg-neon/pom.xml
+++ b/lora-codec-twtg-neon/pom.xml
@@ -31,7 +31,7 @@
         <slf4j.version>1.7.32</slf4j.version>
         <graalvm.version>22.0.0</graalvm.version>
 
-        <spring-boot-dependencies.version>3.5.11</spring-boot-dependencies.version>
+        <spring-boot-dependencies.version>4.1.0</spring-boot-dependencies.version>
         <microservice.name>lora-codec-twtg-neon</microservice.name>
         <main.class>com.cumulocity.lora.codec.twtg.neon.Application</main.class>
     </properties>

--- a/lora-codec-twtg-neon/pom.xml
+++ b/lora-codec-twtg-neon/pom.xml
@@ -31,7 +31,7 @@
         <slf4j.version>1.7.32</slf4j.version>
         <graalvm.version>22.0.0</graalvm.version>
 
-        <spring-boot-dependencies.version>4.1.0</spring-boot-dependencies.version>
+        <spring-boot-dependencies.version>4.0.7</spring-boot-dependencies.version>
         <microservice.name>lora-codec-twtg-neon</microservice.name>
         <main.class>com.cumulocity.lora.codec.twtg.neon.Application</main.class>
     </properties>

--- a/microservices/hello-kotlin/pom.xml
+++ b/microservices/hello-kotlin/pom.xml
@@ -88,7 +88,6 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <!-- Spring Boot 4.0 moved @WebMvcTest / MockMvc test support out of spring-boot-starter-test. -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-webmvc-test</artifactId>

--- a/microservices/hello-kotlin/pom.xml
+++ b/microservices/hello-kotlin/pom.xml
@@ -16,7 +16,8 @@
 
     <properties>
         <jetbrains-annotations.version>23.0.0</jetbrains-annotations.version>
-        <kotlin.version>1.9.25</kotlin.version>
+        <kotlin.version>2.3.21</kotlin.version> <!-- Spring Boot 4 requires Kotlin 2.2+; aligned with the version managed by the Spring Boot 4.1 BOM -->
+
         <springmockk.version>4.0.2</springmockk.version>
     </properties>
 
@@ -86,6 +87,12 @@
                     <artifactId>mockito-core</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <!-- Spring Boot 4.0 moved @WebMvcTest / MockMvc test support out of spring-boot-starter-test. -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-webmvc-test</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework.security</groupId>

--- a/microservices/hello-kotlin/src/test/kotlin/c8y/example/hellokotlin/HelloKotlinControllerTest.kt
+++ b/microservices/hello-kotlin/src/test/kotlin/c8y/example/hellokotlin/HelloKotlinControllerTest.kt
@@ -9,7 +9,9 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.BeforeEach
 import org.springframework.beans.factory.annotation.Autowired
 
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.boot.web.server.autoconfigure.ServerProperties
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest
 import org.springframework.context.annotation.Import
 import org.springframework.http.MediaType
 import org.springframework.security.test.context.support.WithMockUser
@@ -18,6 +20,9 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
 
 @WebMvcTest
+// Spring Boot 4's @WebMvcTest slice no longer includes ServerProperties, which the microservice
+// security auto-configuration requires; register it explicitly.
+@EnableConfigurationProperties(ServerProperties::class)
 @Import(SecurityMocksInitializer::class)
 internal class HelloKotlinControllerTest(@Autowired val mockMvc: MockMvc, @Autowired val mocksInitializer: SecurityMocksInitializer) {
 

--- a/microservices/iptracker-microservice/pom.xml
+++ b/microservices/iptracker-microservice/pom.xml
@@ -14,7 +14,7 @@
     <java.version>17</java.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
-    <spring-boot.version>4.1.0</spring-boot.version>
+    <spring-boot.version>4.0.7</spring-boot.version>
     <c8y.version>${revision}${changelist}</c8y.version>
     <microservice.name>iptracker-microservice</microservice.name>
   </properties>

--- a/microservices/iptracker-microservice/pom.xml
+++ b/microservices/iptracker-microservice/pom.xml
@@ -9,7 +9,7 @@
   <url>http://maven.apache.org</url>
 
   <properties>
-    <revision>2026.42.0</revision>
+    <revision>2026.43.0</revision>
     <changelist>-SNAPSHOT</changelist>
     <java.version>17</java.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>

--- a/microservices/iptracker-microservice/pom.xml
+++ b/microservices/iptracker-microservice/pom.xml
@@ -9,12 +9,12 @@
   <url>http://maven.apache.org</url>
 
   <properties>
-    <revision>2026.42.0</revision>
+    <revision>2026.40.2001</revision>
     <changelist>-SNAPSHOT</changelist>
     <java.version>17</java.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
-    <spring-boot.version>3.5.11</spring-boot.version>
+    <spring-boot.version>4.1.0</spring-boot.version>
     <c8y.version>${revision}${changelist}</c8y.version>
     <microservice.name>iptracker-microservice</microservice.name>
   </properties>

--- a/microservices/iptracker-microservice/pom.xml
+++ b/microservices/iptracker-microservice/pom.xml
@@ -9,7 +9,7 @@
   <url>http://maven.apache.org</url>
 
   <properties>
-    <revision>2026.40.2001</revision>
+    <revision>2026.42.0</revision>
     <changelist>-SNAPSHOT</changelist>
     <java.version>17</java.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <nexus.basePath>/nexus/content/repositories</nexus.basePath>
 
     <c8y.version>${project.version}</c8y.version>
-    <spring-boot.version>4.1.0</spring-boot.version>
+    <spring-boot.version>4.0.7</spring-boot.version>
     <bouncycastle.version>1.83</bouncycastle.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,12 +11,9 @@
   <packaging>pom</packaging>
 
   <properties>
-    <revision>2026.40.2001</revision>
+    <revision>2026.42.0</revision>
     <changelist>-SNAPSHOT</changelist>
 
-    <project.version>2026.40.2001-SNAPSHOT</project.version>
-    <project.parent.version>${project.version}</project.parent.version>
-    <c8y.microservice.version>${project.version}</c8y.microservice.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.version>17</java.version>
     <microservice.java.version>${java.version}</microservice.java.version>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   <packaging>pom</packaging>
 
   <properties>
-    <revision>2026.42.0</revision>
+    <revision>2026.43.0</revision>
     <changelist>-SNAPSHOT</changelist>
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -11,9 +11,12 @@
   <packaging>pom</packaging>
 
   <properties>
-    <revision>2026.42.0</revision>
+    <revision>2026.40.2001</revision>
     <changelist>-SNAPSHOT</changelist>
 
+    <project.version>2026.40.2001-SNAPSHOT</project.version>
+    <project.parent.version>${project.version}</project.parent.version>
+    <c8y.microservice.version>${project.version}</c8y.microservice.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.version>17</java.version>
     <microservice.java.version>${java.version}</microservice.java.version>
@@ -21,7 +24,7 @@
     <nexus.basePath>/nexus/content/repositories</nexus.basePath>
 
     <c8y.version>${project.version}</c8y.version>
-    <spring-boot.version>3.5.11</spring-boot.version>
+    <spring-boot.version>4.1.0</spring-boot.version>
     <bouncycastle.version>1.83</bouncycastle.version>
   </properties>
 


### PR DESCRIPTION
**Problem**
To be up-to-date with the new features, and reduce security risks, regular Spring Boot updates are needed.

**Solution**
Spring Boot is updated from version 3.5.15 to version **4.0.7** 

This update causes a variety of changes related mostly to third-party dependencies. Still, wherever possible, certain third-party libraries' old versions are kept and their updates will be tackled separately. The examples are updated to use the new dependencies versions and whenever needed, also the code base was adapted.

- Spring Framework 7.0.8
- Jetty 12.1.10
**- CometD 9.0.1**
- Jersey is pinned to 3.1.12 despite Spring Boot 4 ships Jersey 4.0
- Apache Http Client 4.5.14
- Jackson  pinned to 2.21.4 and the shipped version 3 is excluded. 

This PR is caused by: 
* https://github.com/Cumulocity-IoT/cumulocity-clients-java-internal/pull/451